### PR TITLE
Added destination fallback and conflict removal.

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -255,6 +255,14 @@ class AuthController extends ControllerBase {
 
     $returnTo = $request->request->get('returnTo', $request->query->get('returnTo', NULL));
 
+    // If the 'destination' parameter is set, core will highjack our redirect.
+    // Unset it if it exists, and fall back to using it if no 'returnTo' is set.
+    $destination = $request->query->get('destination', NULL);
+    if ($destination) {
+      $request->query->remove('destination');
+      $returnTo = $returnTo ?? $destination;
+    }
+
     // If supporting SSO, redirect to the hosted login page for authorization.
     if ($this->redirectForSso) {
       return new TrustedRedirectResponse($this->buildAuthorizeUrl(NULL, $returnTo));


### PR DESCRIPTION
### Changes

It's common for authentication-related modules to send the user to the login page with a destination parameter set, so they can be redirected back to what they were trying to do prior to being prompted to log in. The [Require Login](https://www.drupal.org/project/require_login) module is a good example.

This redirect is performed by Drupal core. When the Auth0 Drupal module is set to redirect to the Auth0 hosted Universal Login Page for authentication, these two redirects can clash and the core redirect highjacks the Auth0 Drupal redirect.

For example, if the user visits `/user/login?destination=/`, Auth0 Drupal will catch that request (via the `auth0.login` route) and attempt to redirect the user to Auth0 Universal Login. However, Drupal core will see the `destination` parameter and redirect the user to `/`. In my testing, the Drupal core redirect happens last and "wins" and the user is never sent over to Auth0.

This PR checks if the clashing `destination` parameter is set during the login request handling. If it is set, it gets unset and the module uses it as a fallback for the `returnTo` value.